### PR TITLE
shrink request message channel capacity

### DIFF
--- a/trmq.go
+++ b/trmq.go
@@ -58,7 +58,7 @@ func (q *MessageQueue) Consume() (chan *RequestMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	req_ch := make(chan *RequestMessage, 100)
+	req_ch := make(chan *RequestMessage)
 	go func() {
 		for msg := range ch {
 			ret := new(RequestMessage)

--- a/trmq.go
+++ b/trmq.go
@@ -67,10 +67,11 @@ func (q *MessageQueue) Consume() (chan *RequestMessage, error) {
 				log.Printf("fail to decode request message from TRMQ: %s", err.Error())
 				msg.Nack(false, false)
 			} else {
-				msg.Ack(false)
 				ret.ReplyTo = msg.ReplyTo
 				ret.CorrelationId = msg.CorrelationId
 				req_ch <- ret
+				// send Ack after message was accepted by a processing goroutine (note that the capacity of req_ch is 0).
+				msg.Ack(false)
 			}
 		}
 		log.Print("TRMQ connection closed.")

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version string = "0.1.0"
+const Version string = "0.1.1"


### PR DESCRIPTION
Don't prefetch messages from AMQP and ack after message handling to improve message durability.
- [ ] @kamito 
