### PR TITLE
wait until backend application server start to listen the socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.3
+
+- Wait until backend application server start to listen socket before
+  dispatching requests.
+
 ## 0.1.2
 
 - Just rebuild with Go 1.5.3 for fix potential vulnerability.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 (In your Dockerfile)
 ```
-ADD https://github.com/groovenauts/magellan-proxy/releases/download/v0.1.2/magellan-proxy-0.1.2_linux-amd64 /usr/app/magellan-proxy
+ADD https://github.com/groovenauts/magellan-proxy/releases/download/v0.1.3/magellan-proxy-0.1.3_linux-amd64 /usr/app/magellan-proxy
 RUN chmod +x /usr/app/magellan-proxy
 ```
 

--- a/trmq.go
+++ b/trmq.go
@@ -53,12 +53,11 @@ func (q *MessageQueue) Close() {
 	q.Connection.Close()
 }
 
-func (q *MessageQueue) Consume() (chan *RequestMessage, error) {
+func (q *MessageQueue) Consume(req_ch chan *RequestMessage) error {
 	ch, err := q.Channel.Consume(q.RequestQueue, "_magellan_proxy_consumer", false, false, false, false, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	req_ch := make(chan *RequestMessage)
 	go func() {
 		for msg := range ch {
 			ret := new(RequestMessage)
@@ -79,7 +78,7 @@ func (q *MessageQueue) Consume() (chan *RequestMessage, error) {
 		self.Signal(syscall.SIGTERM)
 	}()
 
-	return req_ch, nil
+	return nil
 }
 
 func (q *MessageQueue) Publish(req *RequestMessage, res *Response) error {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version string = "0.1.2"
+const Version string = "0.1.3"


### PR DESCRIPTION
At the startup time, until backend application server start to listen the socket, dispatching request to the application server failed with `connection refused` or such kind of error.
Now magellan-proxy wait until backend application server start to listen the socket before start dispatching requests.
- [x] @kamito 
- [x] @minimum2scp 
