### PR TITLE
wait child process at exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.1.4
+
+- Wait child process exited before exit.
+  I hope this can be workaround for kernel hang at docker container exit time on aufs.
+  see https://github.com/docker/docker/issues/14816
+      https://github.com/docker/docker/issues/13940
+      https://github.com/docker/docker/issues/9862
+
 ## 0.1.3
 
 - Wait until backend application server start to listen socket before

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 (In your Dockerfile)
 ```
-ADD https://github.com/groovenauts/magellan-proxy/releases/download/v0.1.3/magellan-proxy-0.1.3_linux-amd64 /usr/app/magellan-proxy
+ADD https://github.com/groovenauts/magellan-proxy/releases/download/v0.1.4/magellan-proxy-0.1.4_linux-amd64 /usr/app/magellan-proxy
 RUN chmod +x /usr/app/magellan-proxy
 ```
 

--- a/magellan-proxy.go
+++ b/magellan-proxy.go
@@ -90,8 +90,9 @@ func watchChild(child *os.Process, sigchan chan os.Signal) {
 
 func processSignal(sigchan chan os.Signal, child *os.Process, req_ch chan *RequestMessage, exitQueue chan bool) {
 	sig := <-sigchan
-	_ = child.Signal(sig)
 	close(req_ch)
+	_ = child.Signal(sig)
+	_, _ = child.Wait()
 	exitQueue <- true
 	close(exitQueue)
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version string = "0.1.3"
+const Version string = "0.1.4"


### PR DESCRIPTION
magellan-proxy is designed to be used in a container.
Docker container rarely hangs at exit on Linux kernel 3.18 or earlier.
  https://github.com/docker/docker/issues/14816
  https://github.com/docker/docker/issues/13940
  https://github.com/docker/docker/issues/9862

Some comments pointed out that the dangling child process in a container was essential for this issue.
I'm not so confident with this workaround. I hope this cease random hang-ups on MAGELLAN.
- [x] @minimum2scp 
