### PR TITLE
Send SIGTERM on consume error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.1.7
+
+- Send SIGTERM when amqp.Channel.Consume returns error
+
+## 0.1.6
+
+- Support --timeout option to wait until backend application server start to listen socket
+
 ## 0.1.5
 
 - Support --timezone option to set Time Zone in log timestamp.

--- a/trmq.go
+++ b/trmq.go
@@ -82,8 +82,15 @@ func (q *MessageQueue) Consume(req_ch chan *RequestMessage) error {
 }
 
 func (q *MessageQueue) SendToMyself(signal os.Signal) {
-	self, _ := os.FindProcess(os.Getpid())
-	self.Signal(signal)
+	pid := os.Getpid()
+	self, err := os.FindProcess(pid)
+	if err != nil {
+		log.Printf("Error on os.FindProcess for %v because of %v\n", pid, err)
+		return
+	}
+	if err := self.Signal(signal); err != nil {
+		log.Printf("Error on send %v to %v because of %v\n", signal, pid, err)
+	}
 }
 
 func (q *MessageQueue) Publish(req *RequestMessage, res *Response) error {

--- a/trmq.go
+++ b/trmq.go
@@ -74,11 +74,15 @@ func (q *MessageQueue) Consume(req_ch chan *RequestMessage) error {
 			}
 		}
 		log.Print("TRMQ connection closed.")
-		self, _ := os.FindProcess(os.Getpid())
-		self.Signal(syscall.SIGTERM)
+		q.SendToMyself(syscall.SIGTERM)
 	}()
 
 	return nil
+}
+
+func (q *MessageQueue) SendToMyself(signal os.Signal) {
+	self, _ := os.FindProcess(os.Getpid())
+	self.Signal(signal)
 }
 
 func (q *MessageQueue) Publish(req *RequestMessage, res *Response) error {

--- a/trmq.go
+++ b/trmq.go
@@ -56,6 +56,7 @@ func (q *MessageQueue) Close() {
 func (q *MessageQueue) Consume(req_ch chan *RequestMessage) error {
 	ch, err := q.Channel.Consume(q.RequestQueue, "_magellan_proxy_consumer", false, false, false, false, nil)
 	if err != nil {
+		q.SendToMyself(syscall.SIGTERM)
 		return err
 	}
 	go func() {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version string = "0.1.6"
+const Version string = "0.1.7"


### PR DESCRIPTION
- Send SIGTERM on Consume error
- Add error loggings around sending signal and child process
