### PR TITLE
touch a file if child process was killed by SIGKILL.

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version string = "0.1.8"
+const Version string = "0.1.9"


### PR DESCRIPTION
Create empty file in /var/tmp/oom_killed when child process was killed by SIGKILL.

When the container was restarted (like `docker restart`), the child process can detect that the previous process was killed by SIGKILL (and it can be assumed that it was due to OOM Killer).
